### PR TITLE
(SIMP-481) Allow directories in keydist/cacerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
@@ -7,17 +7,46 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.10'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,18 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
 
-# For playing nice with mock
-File.umask(027)
-
-require 'simp/rake/pkg'
-
+# These gems aren't always present, for instance
+# on Travis with --without development
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'puppet_blacksmith/rake_tasks'
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
 end
+
+
+# FIXME: move all this lint logic into simp-rake-helpers
+Rake::Task[:lint].clear
 
 # Lint Material
 begin
@@ -18,10 +21,64 @@ begin
   PuppetLint.configuration.send("disable_80chars")
   PuppetLint.configuration.send("disable_variables_not_enclosed")
   PuppetLint.configuration.send("disable_class_parameter_defaults")
+
+  PuppetLint.configuration.relative = true
+  PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+  #PuppetLint.configuration.fail_on_warnings = true
+
+  # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+  # http://puppet-lint.com/checks/class_parameter_defaults/
+  PuppetLint.configuration.send('disable_class_parameter_defaults')
+  # http://puppet-lint.com/checks/class_inherits_from_params_class/
+  PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+  exclude_paths = [
+    "bundle/**/*",
+    "pkg/**/*",
+    "dist/**/*",
+    "vendor/**/*",
+    "spec/**/*",
+  ]
+  PuppetLint.configuration.ignore_paths = exclude_paths
+  PuppetSyntax.exclude_paths = exclude_paths
 rescue LoadError
   puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+begin
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
+rescue LoadError
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
+
+begin
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
+rescue LoadError
+  # Ignoring this for now since all of these are currently convenience methods.
+end
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-pki.spec
+++ b/build/pupmod-pki.spec
@@ -1,7 +1,7 @@
 Summary: PKI Puppet Module
 Name: pupmod-pki
 Version: 4.1.0
-Release: 4
+Release: 5
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -55,6 +55,12 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Oct 13 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.0-5
+- If a directory is placed in keydist/cacerts, the directory structure is copied
+  to pki/cacerts, and all certs in subdirectories are appended to cacerts.pem.
+- If a directory is removed from keydist/cacerts, it is now forcibly removed
+  from .cacerts_ingress.
+
 * Thu Feb 12 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-4
 - Moved things to the new 'simp' environment
 - Ensure the requirements on packages are appropriately defined

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class pki (
     recurse      => true,
     mode         => '0644',
     purge        => true,
+    force        => true,
     seltype      => 'cert_t',
     source       => [
       'puppet:///modules/pki/keydist/cacerts',

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,53 @@
+{
+  "name":    "pupmod-simp-pki",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "Manage pki",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-pki",
+  "project_page": "https://github.com/simp/pupmod-simp-pki",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "pki" ],
+  "dependencies": [
+    {
+      "name": "simp-common",
+      "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "simp-auditd",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-concat",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-iptables",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 4.1.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,158 @@
+require 'spec_helper_acceptance'
+
+test_name 'pki_sync'
+
+describe 'pki_sync' do
+
+  let(:manifest) {
+  <<-EOS
+  file { '/etc/pki/cacerts':
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    seltype => 'cert_t',
+    recurse => true,
+    tag     => 'firstrun'
+  }
+  pki_cert_sync { '/etc/pki/cacerts':
+    source => '/etc/pki/simp-testing/pki/cacerts/',
+    purge  => true,
+  }
+  EOS
+  }
+
+  let(:no_purge_manifest) {
+  <<-EOS
+  file { '/etc/pki/cacerts':
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    seltype => 'cert_t',
+    recurse => true,
+    tag     => 'firstrun'
+  }
+  pki_cert_sync { '/etc/pki/cacerts':
+    source => '/etc/pki/simp-testing/pki/cacerts/',
+    purge => false
+  }
+  EOS
+  }
+
+  hosts.each do |host|
+
+    # Generate and copy over some cacerts
+    run_fake_pki_ca_on(host, host)
+    copy_keydist_to(host, '/root/keydist1')
+    run_fake_pki_ca_on(host, host)
+    copy_keydist_to(host, '/root/keydist2')
+
+    # Create a subdirectory in simp-testing/pki/cacerts, and copy over the newly
+    # created CA.
+    on host, "mkdir -p /etc/pki/simp-testing/pki/cacerts/some/subdirectory"
+    on host, "cp /root/keydist1/cacerts/*.pem /etc/pki/simp-testing/pki/cacerts/some/subdirectory"
+    on host, "chgrp -R puppet /etc/pki/simp-testing/"
+
+    context 'default parameters (purge = true)' do
+
+      #
+      # Given default params and one cert: expect the cert to be synced, a symlink
+      # created for it, and its contents added to cacerts.pem
+      #
+      it 'should work with no errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      describe file('/etc/pki/cacerts/') {
+        it { is_expected.to be_file }
+      }
+
+      it 'the cacert should be synced' do
+        on host, "cmp $(find /etc/pki/simp-testing/pki/cacerts/some/subdirectory/ /etc/pki/cacerts/some/subdirectory/ -name cacert_*.pem)", :acceptable_exit_codes => [0]
+      end
+
+      it 'a link to the cert should be created at the top level' do
+        on host, "ls -l /etc/pki/cacerts/ | grep $(ls /etc/pki/cacerts/some/subdirectory/ | grep .pem)", :acceptable_exit_codes => [0]
+      end
+
+      it 'the cert should be appended to cacerts.pem' do
+        on host, "grep $(sed 's/^-.*//g' /etc/pki/cacerts/some/subdirectory/*.pem | tr -d '\n') <<< $(sed 's/^-.*//g' /etc/pki/cacerts/cacerts.pem | tr -d '\n')", :acceptable_exit_codes => [0]
+      end
+
+      #
+      # If a CA cert is added to the top level while purge=true,  expect
+      # it to be removed.
+      #
+      it 'copy non synced cert into /etc/pki/cacerts' do
+        on host, "cp /root/keydist2/cacerts/*.pem /etc/pki/cacerts"
+      end
+
+      it 'should purge non synced certs' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'the purged file should not exist' do
+        on host, "[[ -f /etc/pki/cacerts/$(ls /root/keydist2/cacerts/ | grep .pem) ]]", :acceptable_exit_codes => [1]
+      end
+
+      #
+      # If a malformed cert is added to the sync directory, it should not be synced.
+      #
+      #
+      it 'generate malformed cert in /etc/pki/simp-testing/pki/cacerts' do
+        on host, "touch /etc/pki/simp-testing/pki/cacerts/foofile"
+      end
+
+      it 'sync should not copy malformed cert' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'malformed cert should not exist in /etc/pki/cacerts' do
+        on host, "[[ -f /etc/pki/cacerts/foofile ]]", :acceptable_exit_codes => [1]
+      end
+
+      it 'remove malformed cert from sync directory' do
+        on host, "rm -f /etc/pki/simp-testing/pki/cacerts/foofile"
+      end
+
+      #
+      # If a cacert is removed from the sync directory, it should be purged, but
+      # any residual directory structure should remain.
+      #
+      it 'removing /etc/pki/simp-testing/pki/cacerts/some/subdirectory/*.pem' do
+        on host, "rm -f /etc/pki/simp-testing/pki/cacerts/some/subdirectory/*.pem"
+      end
+
+      it 'purge deleted cert' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
+
+      it 'deleted cert should be removed from sync directory' do
+        on host, "ls -A /etc/pki/cacerts/some/subdirectory/ | grep pem", :acceptable_exit_codes => [1]
+      end
+
+      it 'but the directory should still exist' do
+        on host, "ls -A /etc/pki/cacerts/some/subdirectory", :acceptable_exit_codes => [0]
+      end
+    end
+
+    #
+    # Set purged = false.  If a cert is copied into /etc/pki/cacerts, it
+    # should exist after puppet apply.
+    #
+    context 'with purge = false' do
+      it 'copy non synced cert into /etc/pki/cacerts' do
+        on host, "cp /root/keydist2/cacerts/*.pem /etc/pki/cacerts"
+      end
+
+      it 'should not purge non-synced cert' do
+        apply_manifest_on(host, no_purge_manifest, :catch_failures => true)
+      end
+
+      it 'the purged file should not exist' do
+        on host, "[[ -f /etc/pki/cacerts/$(ls /root/keydist2/cacerts/ | grep .pem) ]]", :acceptable_exit_codes => [0]
+      end
+    end
+  end
+end

--- a/spec/acceptance/nodesets/centos-511-x64.yml
+++ b/spec/acceptance/nodesets/centos-511-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  centos-511-x64:
+    roles:
+      - master
+    platform: el-5-x86_64
+    box: puppetlabs/centos-5.11-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-5.11-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-66-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-7-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/debian-609-x64.yml
+++ b/spec/acceptance/nodesets/debian-609-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  debian-609-x64:
+    roles:
+      - master
+    platform: debian-6-amd64
+    box: puppetlabs/debian-6.0.9-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-6.0.9-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/debian-76-x64.yml
+++ b/spec/acceptance/nodesets/debian-76-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  debian-76-x64:
+    roles:
+      - master
+    platform: debian-7-amd64
+    box: puppetlabs/debian-7.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-7.6-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,19 @@
+HOSTS:
+  centos7:
+    roles:
+      - default
+      - server
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+  centos66:
+    roles:
+      - server
+    platform: el-6-x86_64
+    box: puppetlabs/centos-6.6-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/fedora-20-x64.yml
+++ b/spec/acceptance/nodesets/fedora-20-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  fedora-20-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: chef/fedora-20
+    box_url: https://vagrantcloud.com/chef/boxes/fedora-20
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1204-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-server-1204-x64:
+    roles:
+      - master
+    platform: ubuntu-1204-amd64
+    box: puppetlabs/ubuntu-12.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-12.04-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-1404-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,25 +1,25 @@
 require 'spec_helper'
 
 describe 'pki' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      let(:facts) do
+        facts.merge( { :fqdn => 'test.example.domain' } )
+      end
 
-  let(:facts) {{
-    :fqdn => 'test.example.domain',
-    :operatingsystem => 'RedHat',
-    :grub_version => '0.9',
-    :uid_min => '500'
-  }}
+      it { is_expected.to create_class('pki') }
 
-  it { should create_class('pki') }
-
-  context 'base' do
-    it { should compile.with_all_deps }
-    it { should contain_class('auditd') }
-
-    it { should create_file('/etc/pki').with_ensure('directory') }
-    it { should create_file('/etc/pki/private').with_ensure('directory') }
-    it { should create_file('/etc/pki/public').with_ensure('directory') }
-    it { should create_file('/etc/pki/private/test.example.domain.pem') }
-    it { should create_file('/etc/pki/public/test.example.domain.pub') }
-    it { should create_file('/etc/pki/cacerts').with_ensure('directory') }
+      context 'base' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('auditd') }
+    
+        it { is_expected.to create_file('/etc/pki').with_ensure('directory') }
+        it { is_expected.to create_file('/etc/pki/private').with_ensure('directory') }
+        it { is_expected.to create_file('/etc/pki/public').with_ensure('directory') }
+        it { is_expected.to create_file('/etc/pki/private/test.example.domain.pem') }
+        it { is_expected.to create_file('/etc/pki/public/test.example.domain.pub') }
+        it { is_expected.to create_file('/etc/pki/cacerts').with_ensure('directory') }
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,11 @@
-require 'pathname'
-require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet'
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
+require 'pathname'
 
 # RSpec Material
-
-def mod_site_pp(content)
-  File.open(@orig_site_pp,'w'){|f| f.write(content) }
-end
-
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
 
@@ -18,6 +16,12 @@ if Puppet.version < "4.0.0"
   end
 end
 
+
+if !ENV.key?( 'TRUSTED_NODE_DATA' )
+  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
+  ENV['TRUSTED_NODE_DATA']='yes'
+end
+
 default_hiera_config =<<-EOM
 ---
 :backends:
@@ -26,12 +30,47 @@ default_hiera_config =<<-EOM
 :yaml:
   :datadir: "stub"
 :hierarchy:
-  # This is a variable that you can set in your test classes to ensure that the
-  # targeted YAML file gets loaded in the fixtures.
+  - "%{custom_hiera}"
   - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM
+
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
 
 if not File.directory?(File.join(fixture_path,'hieradata')) then
   FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
@@ -41,15 +80,16 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
 RSpec.configure do |c|
+  # If nothing else...
+  c.default_facts = {
+    :production => {
+      #:fqdn           => 'production.rspec.test.localdomain',
+      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+      :concat_basedir => '/tmp'
+    }
+  }
+
   c.mock_framework = :rspec
   c.mock_with :mocha
 
@@ -58,35 +98,52 @@ RSpec.configure do |c|
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
-  c.before(:all) do
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
+  # Useless backtrace noise
+  backtrace_exclusion_patterns = [
+    /spec_helper/,
+    /gems/
+  ]
 
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+
+  c.before(:all) do
     data = YAML.load(default_hiera_config)
-    data[:yaml][:datadir] = File.join(fixture_path, 'hieradata').to_s
+    data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
     end
-
-    @orig_site_pp = File.join(c.manifest_dir,'site.pp')
-    @orig_site_pp_content = File.read(@orig_site_pp)
   end
 
   c.before(:each) do
-    @spec_global_env_temp = Dir.mktmpdir('simptest')
+    @spec_global_env_temp = Dir.mktmpdir('simpspec')
+
+    if defined?(environment)
+      set_environment(environment)
+      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
+    end
+
+    # ensure the user running these tests has an accessible environmentpath
     Puppet[:environmentpath] = @spec_global_env_temp
+    Puppet[:user] = Etc.getpwuid(Process.uid).name
+    Puppet[:group] = Etc.getgrgid(Process.gid).name
+
+    # sanitize hieradata
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
+    end
   end
 
   c.after(:each) do
+    # clean up the mocked environmentpath
     FileUtils.rm_rf(@spec_global_env_temp)
-  end
-
-  c.after(:all) do
-    mod_site_pp(@orig_site_pp_content)
+    @spec_global_env_temp = nil
   end
 end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,45 @@
+require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+
+RSpec.configure do |c|
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    begin
+      # Install modules and dependencies from spec/fixtures/modules
+      copy_fixture_modules_to( hosts )
+
+      # Generate and install PKI certificates on each SUT
+      Dir.mktmpdir do |cert_dir|
+        run_fake_pki_ca_on( default, hosts, cert_dir )
+        hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
+      end
+    rescue StandardError, ScriptError => e
+      if ENV['PRY']
+        require 'pry'; binding.pry
+      else
+        raise e
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a directory is placed in keydist/cacerts, the directory structure is copied
to pki/cacerts, and all certs in subdirectories are appended to cacerts.pem.

If a directory is removed from keydist/cacerts, it is now forcibly removed
from .cacerts_ingress.

SIMP-481 #close Directories in keydist/cacerts