### PR TITLE
(SIMP-999) Remove custom type warning in pupmod-simp-pki

### DIFF
--- a/build/pupmod-pki.spec
+++ b/build/pupmod-pki.spec
@@ -1,7 +1,7 @@
 Summary: PKI Puppet Module
 Name: pupmod-pki
 Version: 4.2.1
-Release: 0
+Release: 1
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -52,6 +52,9 @@ mkdir -p %{buildroot}/%{prefix}/pki
 # Post uninstall stuff
 
 %changelog
+* Tue Apr 12 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 4.2.1-1
+- Removed custom type deprecation warning
+
 * Mon Mar 28 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.1-0
 - Removed extraneous cacerts keys
 - Updated the README

--- a/lib/puppet/type/pki_cert_sync.rb
+++ b/lib/puppet/type/pki_cert_sync.rb
@@ -1,98 +1,96 @@
-module Puppet
-  newtype(:pki_cert_sync) do
-    require 'puppet/util/selinux'
-    include Puppet::Util::SELinux
+Puppet::Type.newtype(:pki_cert_sync) do
+  require 'puppet/util/selinux'
+  include Puppet::Util::SELinux
 
-    @doc = <<-EOM
-      A puppet type for merging the contents of one directory full of X.509 PKI
-      certificates into another while hashing the certificates in a manner
-      appropriate for use by most Linux applications (Apache, OpenLDAP, etc...).
+  @doc = <<-EOM
+    A puppet type for merging the contents of one directory full of X.509 PKI
+    certificates into another while hashing the certificates in a manner
+    appropriate for use by most Linux applications (Apache, OpenLDAP, etc...).
 
-      Usage:
+    Usage:
 
-      pki_cert_sync { '<target_dir>': source => '<source_dir>' }
+    pki_cert_sync { '<target_dir>': source => '<source_dir>' }
 
-      Both directories must exist on the local operating system, remote file
-      syncing is not supported. File attributes will all be copied from the
-      source directory.
+    Both directories must exist on the local operating system, remote file
+    syncing is not supported. File attributes will all be copied from the
+    source directory.
 
-      Any SELinux contexts will be preserved on existing files and copied from
-      the source files if the destination file does not exist.
+    Any SELinux contexts will be preserved on existing files and copied from
+    the source files if the destination file does not exist.
+  EOM
+
+  def initialize(args)
+    super(args)
+
+    if self[:tag] then
+      self[:tag] += ['pki']
+    else
+      self[:tag] = ['pki']
+    end
+
+    if self[:notify] then
+      self[:notify] += ["File[#{self[:name]}]"]
+    else
+      self[:notify] = ["File[#{self[:name]}]"]
+    end
+  end
+
+  def finish
+    # Do stuff here if necessary after the catalog compiles.
+
+    super
+  end
+
+  newparam(:name, :namevar => true) do
+    desc = <<-EOM
+      The target directory into which to place and hash the X.509
+      certificates.
+
+      This directory will be left as it was found at the end of the sync just
+      in case it is the destination of a recursive file copy with purge
+      enabled.
     EOM
 
-    def initialize(args)
-      super(args)
-
-      if self[:tag] then
-        self[:tag] += ['pki']
-      else
-        self[:tag] = ['pki']
-      end
-
-      if self[:notify] then
-        self[:notify] += ["File[#{self[:name]}]"]
-      else
-        self[:notify] = ["File[#{self[:name]}]"]
-      end
+    validate do |value|
+      Puppet::Util.absolute_path?(value) or
+        fail Puppet::Error, "Target directory must be an absolute path, not '#{value}'"
     end
-
-    def finish
-      # Do stuff here if necessary after the catalog compiles.
-
-      super
-    end
-
-    newparam(:name, :namevar => true) do
-      desc = <<-EOM
-        The target directory into which to place and hash the X.509
-        certificates.
-
-        This directory will be left as it was found at the end of the sync just
-        in case it is the destination of a recursive file copy with purge
-        enabled.
-      EOM
-
-      validate do |value|
-        Puppet::Util.absolute_path?(value) or
-          fail Puppet::Error, "Target directory must be an absolute path, not '#{value}'"
-      end
-    end
-
-    newparam(:purge, :boolean => true) do
-      desc = <<-EOM
-        Whether or not to purge the target directory (:name). In general, you
-        will want to do this to ensure that systems do not get inappropriate
-        CAs added locally.
-      EOM
-
-      newvalues(:true,:false)
-      defaultto :true
-    end
-
-    newproperty(:source) do
-      desc = <<-EOM
-        The directory into which to copy all materials. All existing materials will be removed.
-      EOM
-
-      validate do |value|
-        Puppet::Util.absolute_path?(value) or
-          fail Puppet::Error, "Source directory must be an absolute path, not '#{value}'"
-      end
-
-      def insync?(is)
-        # In this case, we want to compare the contents of ourself and
-        # self[:name].
-        provider.source_insync?(is,resource[:name])
-      end
-
-      def change_to_s(currentvalue, newvalue)
-        "'#{resource[:source]}' X.509 CA certificates sync'd to '#{resource[:name]}'"
-      end
-    end
-
-    autorequire(:file) do
-      [ self[:name], self[:source] ]
-    end
-
   end
+
+  newparam(:purge, :boolean => true) do
+    desc = <<-EOM
+      Whether or not to purge the target directory (:name). In general, you
+      will want to do this to ensure that systems do not get inappropriate
+      CAs added locally.
+    EOM
+
+    newvalues(:true,:false)
+    defaultto :true
+  end
+
+  newproperty(:source) do
+    desc = <<-EOM
+      The directory into which to copy all materials. All existing materials will be removed.
+    EOM
+
+    validate do |value|
+      Puppet::Util.absolute_path?(value) or
+        fail Puppet::Error, "Source directory must be an absolute path, not '#{value}'"
+    end
+
+    def insync?(is)
+      # In this case, we want to compare the contents of ourself and
+      # self[:name].
+      provider.source_insync?(is,resource[:name])
+    end
+
+    def change_to_s(currentvalue, newvalue)
+      "'#{resource[:source]}' X.509 CA certificates sync'd to '#{resource[:name]}'"
+    end
+  end
+
+  autorequire(:file) do
+    [ self[:name], self[:source] ]
+  end
+
 end


### PR DESCRIPTION
Removed the custom type deprecation warning from the pki_cert_sync
custom type

SIMP-995 #comment Fixes the pupmod-simp-pki portion of the story
SIMP-999 #close