### PR TITLE
(SIMP-1224) Fix name in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name":    "pupmod-simp-pki",
+  "name":    "simp-pki",
   "version": "4.2.3",
   "author":  "simp",
   "summary": "Manages non-Puppet PKI keys and certificates",


### PR DESCRIPTION
The 'name' in metadata.json should not have 'pupmod-' prepended to it.

SIMP-1224 #comment Fix for pki
SIMP-1229 #close