### PR TITLE
(SIMP-1590) Fix old dependencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 30 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.2.4-0
+- Fixed dependencies in `metadata.json` prior to a Forge push.
+
 * Wed Jul 06 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.3-0
 - Fixed a permissions flapping issue between a file resource and the 'sync'
   provider.

--- a/metadata.json
+++ b/metadata.json
@@ -1,24 +1,23 @@
 {
-  "name":    "simp-pki",
-  "version": "4.2.3",
-  "author":  "simp",
+  "name": "simp-pki",
+  "version": "4.2.4",
+  "author": "simp",
   "summary": "Manages non-Puppet PKI keys and certificates",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-pki",
+  "source": "https://github.com/simp/pupmod-simp-pki",
   "project_page": "https://github.com/simp/pupmod-simp-pki",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "pki" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "pki"
+  ],
   "dependencies": [
-    {
-      "name": "simp/common",
-      "version_requirement": ">= 4.2.0"
-    },
     {
       "name": "simp/auditd",
       "version_requirement": ">= 4.1.0"
     },
     {
-      "name": "simp/concat",
+      "name": "simp/simpcat",
       "version_requirement": ">= 4.0.0"
     },
     {


### PR DESCRIPTION
`simp/common` and `simp/concat` are listed as dependencies in
`metadata.json`, which breaks resolution when installing from the Forge.

This patch fixes the issue by keeping references to `simp/simplib` and
`simp/simpcat`.

SIMP-1590 #close