### PR TITLE
(SIMP-1695) Ensure that selinux contexts are set

### DIFF
--- a/manifests/copy.pp
+++ b/manifests/copy.pp
@@ -64,6 +64,7 @@ define pki::copy (
     mode      => '0640',
     recurse   => true,
     source    => "${source}/public",
+    seltype   => 'cert_t',
     show_diff => false
   }
 
@@ -74,6 +75,7 @@ define pki::copy (
     mode      => '0640',
     recurse   => true,
     source    => "${source}/private",
+    seltype   => 'cert_t',
     show_diff => false
   }
 
@@ -82,9 +84,9 @@ define pki::copy (
     owner     => $owner,
     group     => $group,
     mode      => '0640',
-    seltype   => 'cert_t',
     recurse   => true,
     source    => "${source}/cacerts",
+    seltype   => 'cert_t',
     show_diff => false
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,7 @@ class pki (
     mode      => '0440',
     source    => $private_key_source,
     tag       => 'firstrun',
+    seltype   => 'cert_t',
     show_diff => false
   }
 
@@ -110,6 +111,7 @@ class pki (
     mode      => '0444',
     source    => $public_key_source,
     tag       => 'firstrun',
+    seltype   => 'cert_t',
     show_diff => false
   }
 


### PR DESCRIPTION
The SELinux contexts need to be set on the copied files for
applications to be able to access the certificates.

SIMP-1695 #comment SELinux issues found during testing