### PR TITLE
(SIMP-2463) Set perms on simp_apps to 644/755

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jan 09 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
+- Set perms on simp_apps to 644/755; apps were being denied access to
+  their own certs because they could not access /etc/pki/simp_apps.
+
 * Thu Jan 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - We have made the decision to centralize application certificates
   when simp is managing pki (simp_options::pki => true or 'simp').

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 * Mon Jan 09 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Set perms on simp_apps to 644/755; apps were being denied access to
   their own certs because they could not access /etc/pki/simp_apps.
-
-* Thu Jan 05 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - We have made the decision to centralize application certificates
   when simp is managing pki (simp_options::pki => true or 'simp').
   This update re-tools pki::copy to better handle managing certs

--- a/manifests/copy.pp
+++ b/manifests/copy.pp
@@ -87,14 +87,14 @@ define pki::copy (
       'ensure' => 'directory',
       'owner'  => 'root',
       'group'  => 'root',
-      'mode'   => '0640'}
+      'mode'   => '0644'}
     )
 
     $_destination = "/etc/pki/simp_apps/${name}"
     file { $_destination:
       ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
+      owner  => $owner,
+      group  => $group,
       mode   => '0640'
     }
 


### PR DESCRIPTION
- Apps were being denied access to their own certs because
  they could not access /etc/pki/simp_apps.

SIMP-2463 #close