### PR TITLE
(SIMP-2464) Change default keydist location

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Jan 10 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0
+- Changed default location of keydist certs from the files directory of the pki
+  module unless $pki is set to 'simp', when it will pull from pki_files in a
+  different module path instead.
+
 * Mon Jan 09 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Set perms on simp_apps to 644/755; apps were being denied access to
   their own certs because they could not access /etc/pki/simp_apps.

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 3.1.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,21 +7,22 @@ describe 'pki' do
         facts.merge( { :fqdn => 'test.example.domain' } )
       end
 
-      it { is_expected.to create_class('pki') }
-
-      context 'base' do
+      context 'with default parameters' do
+        it { is_expected.to create_class('pki') }
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to_not contain_class('auditd') }
-    
+
         it { is_expected.to create_file('/etc/pki/simp').with_ensure('directory') }
         it { is_expected.to create_file('/etc/pki/simp/private').with_ensure('directory') }
         it { is_expected.to create_file('/etc/pki/simp/public').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem') }
-        it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub') }
+        it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem') \
+          .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pem') }
+        it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub') \
+          .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pub') }
         it { is_expected.to create_file('/etc/pki/simp/cacerts').with_ensure('directory') }
       end
-    
-      context 'with_auditd' do
+
+      context 'with auditd => true' do
         let(:params){{ :auditd => true }}
 
         it { is_expected.to contain_class('auditd') }
@@ -31,6 +32,16 @@ describe 'pki' do
         it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem') }
         it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub') }
         it { is_expected.to create_file('/etc/pki/simp/cacerts').with_ensure('directory') }
+      end
+
+      [true,false].each do |pki|
+        context "with pki => #{pki}" do
+          let(:params) {{ :pki => pki }}
+
+          it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem').with_source('puppet:///modules/pki/keydist/test.example.domain/test.example.domain.pem') }
+          it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub').with_source('puppet:///modules/pki/keydist/test.example.domain/test.example.domain.pub') }
+          it { is_expected.to create_file('/etc/pki/simp/cacerts').with_ensure('directory') }
+        end
       end
 
     end


### PR DESCRIPTION
- Changed default location of keydist certs from the files directory of
  the pki module unless $pki is set to 'simp', when it will pull from
  pki_files in a different module path instead.