### PR TITLE
(SIMP-2472) Manage certs in x509 directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Wed Jan 11 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
-- SIMP certs are now managed in /etc/pki/simp/x509, and applicaition
+- SIMP certs are now managed in /etc/pki/simp/x509, and application
   certs in /etc/pki/simp_apps/<app_name>/x509.
 
 * Tue Jan 10 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Jan 11 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
+- SIMP certs are now managed in /etc/pki/simp/x509, and applicaition
+  certs in /etc/pki/simp_apps/<app_name>/x509.
+
 * Tue Jan 10 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0
 - Changed default location of keydist certs from the files directory of the pki
   module unless $pki is set to 'simp', when it will pull from pki_files in a

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@
 ## Description
 
 This module provides the capability to manage non-Puppet PKI keys that are
-hosted on the Puppet server. It requires keys to be managed under the PKI
-module at `${environmant}/modules/pki/files/keydist`.
+hosted on the Puppet server.
 
 The `keydist` directory must have the following structure:
 
 ```
-${environment}/modules/pki/files/keydist/
+  Under ${environment}/modules/#{module_name}/files/keydist/
   - cacerts
     - Any X.509 PEM formatted CA certificates that you want to serve to your
       clients. Do NOT hash these certificates. This will be done on the client
@@ -54,7 +53,7 @@ If you find any issues, they can be submitted to our
 ### What simp-pki affects
 
 This module both adds your client X.509 PKI keys to the system at
-`/etc/pki/simp/{cacerts,private,public}` and provides the ability to copy those
+`/etc/pki/simp/x509/{cacerts,private,public}` and provides the ability to copy those
 certificates (or other certificates in the same directory format) into
 application spaces.
 
@@ -105,7 +104,7 @@ For example:
 pki::copy { 'httpd': }
 ```
 
-This will result in the directory `/etc/pki/simp_apps/httpd/pki` being created with the
+This will result in the directory `/etc/pki/simp_apps/httpd/x509` being created with the
 `cacerts`, `public`, and `private` subdirectories as specified in the `keydist`
 directory.
 
@@ -124,7 +123,7 @@ pki::copy { 'httpd':
 ```
 
 This will result in the directory `/foo/bar/pki` being created with the `cacerts`,
-`public`, and `private` subdirectories as specified in the `/etc/pki/simp` directory.
+`public`, and `private` subdirectories as specified in the `/etc/pki/simp/x509` directory.
 
 To change the source of certificates to be distributed, use the global
 pki::source catalyst.
@@ -144,7 +143,7 @@ In a manifest
 pki::copy { 'httpd': }
 ```
 
-This will result in the directory `/etc/pki/simp_apps/httpd/pki` being created with
+This will result in the directory `/etc/pki/simp_apps/httpd/x509` being created with
 the `cacerts`, `public`, and `private` subdirectories as specified in the
 `/some/other/certs` directory.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ hosted on the Puppet server.
 The `keydist` directory must have the following structure:
 
 ```
-  Under ${environment}/modules/#{module_name}/files/keydist/
+  Under `${codedir}/${environment}/modules/#{module_name}/files/keydist/`:
   - cacerts
     - Any X.509 PEM formatted CA certificates that you want to serve to your
       clients. Do NOT hash these certificates. This will be done on the client
@@ -36,6 +36,11 @@ The `keydist` directory must have the following structure:
     - <fqdn>.pem -> Client Private Key
     - <fqdn>.pub -> Client Public Key
 ```
+
+If `$pki` is set to 'simp', the keydist directory will have the same structure,
+however it will be located in a separate module path so keys don't get clobbered
+when using r10k:
+* `/var/simp/environments/${environment}/site_files/pki_files/files/keydist`
 
 
 ### This is a SIMP module

--- a/manifests/copy.pp
+++ b/manifests/copy.pp
@@ -54,7 +54,7 @@
 # @param group
 #   The group of the directories/files that get copied
 #
-# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 define pki::copy (
   Variant[Boolean,Enum['simp']]  $pki         = simplib::lookup('simp_options::pki', { 'default_value' => false}),

--- a/manifests/copy.pp
+++ b/manifests/copy.pp
@@ -5,10 +5,22 @@
 # This is particularly important when dealing with SELinux enabled services
 # since they tend to react poorly to symlinks.
 #
+# @param pki
+#
+#   * If set to ``simp`` or ``true``
+#     * Certificates will be centralized in /etc/pki/simp_apps/, and copied to
+#       /etc/pki/simp_apps/$name/x509.
+#
+#   * If set to ``simp``
+#     * Include the ``::pki`` class
+#
+#   * If set to ``false``
+#     * Certificates will *not* be centralized, and you must provide a $destination
+#
 # @param name [Variant[String,Stdlib::Absolutepath]]
 #
 #   * If $pki = true or $pki = 'simp' this parameter will be used to namespace
-#     certificates in /etc/pki/simp_apps/$name.
+#     certificates in /etc/pki/simp_apps/$name/x509.
 #
 #   * If $pki = false, this variable has no effect.
 #
@@ -27,8 +39,8 @@
 #
 #     * If $pki = false:
 #       * You *must* specify $destination.
-#       * You will need to ensure that all parent directories have been properly
-#         created
+#       * You will need to ensure that all parent directories have been
+#         properly created.
 #       * A 'pki' directory will be created under this space
 #         * For example, if you set this to ``/foo/bar`` then ``/foo/bar/pki``
 #           will be created
@@ -42,26 +54,14 @@
 # @param group
 #   The group of the directories/files that get copied
 #
-# @param pki
-#
-#   * If set to ``simp`` or ``true``
-#     * Certificates will be centralized in /etc/pki/simp_apps/, and copied to
-#       /etc/pki/simp_apps/$name/pki.
-#
-#   * If set to ``simp``
-#     * Include the ``::pki`` class
-#
-#   * If set to ``false``
-#     * Certificates will *not* be centralized, and you must provide a $destination.
-#
 # @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
 #
 define pki::copy (
-  Stdlib::Absolutepath           $source      = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp' }),
+  Variant[Boolean,Enum['simp']]  $pki         = simplib::lookup('simp_options::pki', { 'default_value' => false}),
+  Stdlib::Absolutepath           $source      = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Optional[Stdlib::Absolutepath] $destination = undef,
   String                         $owner       = 'root',
   String                         $group       = 'root',
-  Variant[Boolean,Enum['simp']]  $pki         = simplib::lookup('simp_options::pki', { 'default_value' => false}),
 ) {
 
   if !$pki {
@@ -69,7 +69,14 @@ define pki::copy (
       fail('You must specify a $destination if $pki false.')
     }
     else {
-      $_destination = $destination
+      $_destination = "${destination}/pki"
+
+      file { $_destination:
+        ensure => 'directory',
+        owner  => $owner,
+        group  => $group,
+        mode   => '0640',
+      }
     }
   }
   else {
@@ -78,6 +85,8 @@ define pki::copy (
         message => "Pki is managing cert destination. Ignoring specified destination ${destination}"
       }
     }
+
+    $_destination = "/etc/pki/simp_apps/${name}/x509"
 
     # Only ensure this directory exists if pki is true or 'simp'.
     # There is a reasonable expectation if users have pki globally
@@ -89,13 +98,19 @@ define pki::copy (
       'group'  => 'root',
       'mode'   => '0644'}
     )
-
-    $_destination = "/etc/pki/simp_apps/${name}"
+    file { "/etc/pki/simp_apps/${name}":
+      ensure  => 'directory',
+      owner   => $owner,
+      group   => $group,
+      mode    => '0640',
+      require => File['/etc/pki/simp_apps']
+    }
     file { $_destination:
-      ensure => 'directory',
-      owner  => $owner,
-      group  => $group,
-      mode   => '0640'
+      ensure  => 'directory',
+      owner   => $owner,
+      group   => $group,
+      mode    => '0640',
+      require => File["/etc/pki/simp_apps/${name}"]
     }
 
     if $pki == 'simp' {
@@ -104,14 +119,7 @@ define pki::copy (
     }
   }
 
-  file { "${_destination}/pki":
-    ensure => 'directory',
-    owner  => $owner,
-    group  => $group,
-    mode   => '0640'
-  }
-
-  file { "${_destination}/pki/public":
+  file { "${_destination}/public":
     ensure    => 'directory',
     owner     => $owner,
     group     => $group,
@@ -122,7 +130,7 @@ define pki::copy (
     show_diff => false
   }
 
-  file { "${_destination}/pki/private":
+  file { "${_destination}/private":
     ensure    => 'directory',
     owner     => $owner,
     group     => $group,
@@ -133,7 +141,7 @@ define pki::copy (
     show_diff => false
   }
 
-  file { "${_destination}/pki/cacerts":
+  file { "${_destination}/cacerts":
     ensure    => 'directory',
     owner     => $owner,
     group     => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 #
 # The keydist directory must have the following structure:
 #
-# * ``${environment}/modules/#{module_name}/files/keydist/``
+# * ``${codedir}/${environment}/modules/#{module_name}/files/keydist/``
 #     * cacerts
 #         * Any X.509 PEM formatted CA certificates that you want to serve to
 #           your clients.
@@ -13,6 +13,11 @@
 #               to this particular client.
 #         * <fqdn>.pem -> Host Private Key
 #         * <fqdn>.pub -> Host Public Key
+#
+# If $pki is set to 'simp', the keydist directory will have the same structure,
+# however it will be located in a separate module path so keys don't get clobbered
+# when using r10k:
+# * ``/var/simp/environments/${environment}/site_files/pki_files/files/keydist``
 #
 # @param pki
 #   * If 'simp', certs will be copied from puppet:///modules/pki_files/keydist
@@ -43,7 +48,7 @@
 #   * If set to ``true`` (the default), the ``/etc/pki/cacerts`` directory
 #     will have any non-recognized certificates removed.
 #
-# @author Trevor Vaughan <mailto:tvaughan@onyxpoint.com>
+# @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pki (
   Variant[Boolean,Enum['simp']] $pki                = simplib::lookup('simp_options::pki', { 'default_value' => 'simp' }),

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,10 @@
   "issues_url": "https://simp-project.atlassian.net",
   "tags": [
     "simp",
-    "pki"
+    "pki",
+    "cert",
+    "certs",
+    "key"
   ],
   "dependencies": [
     {
@@ -40,5 +43,16 @@
         "7"
       ]
     }
-  ]
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": "4.x"
+    },
+    {
+      "name": "pe",
+      "version_requirement": ">= 2016.2.0"
+    }
+  ],
+  "data_provider": "hiera"
 }

--- a/spec/acceptance/suites/default/01_copy_spec.rb
+++ b/spec/acceptance/suites/default/01_copy_spec.rb
@@ -28,12 +28,12 @@ describe 'pki_copy' do
 
       # If pki is true or simp, we will manage everything for you!
       it 'should plop the certs in a central place' do
-        on host, "test -f /etc/pki/simp_apps/someapp/pki/private/#{host_fqdn}.pem"
-        on host, "test -f /etc/pki/simp_apps/someapp/pki/public/#{host_fqdn}.pub"
-        on host, "test -f /etc/pki/simp_apps/someapp/pki/cacerts/cacerts.pem"
-        on host, "test -f /etc/pki/simp_apps/anotherapp/pki/private/#{host_fqdn}.pem"
-        on host, "test -f /etc/pki/simp_apps/anotherapp/pki/public/#{host_fqdn}.pub"
-        on host, "test -f /etc/pki/simp_apps/anotherapp/pki/cacerts/cacerts.pem"
+        on host, "test -f /etc/pki/simp_apps/someapp/x509/private/#{host_fqdn}.pem"
+        on host, "test -f /etc/pki/simp_apps/someapp/x509/public/#{host_fqdn}.pub"
+        on host, "test -f /etc/pki/simp_apps/someapp/x509/cacerts/cacerts.pem"
+        on host, "test -f /etc/pki/simp_apps/anotherapp/x509/private/#{host_fqdn}.pem"
+        on host, "test -f /etc/pki/simp_apps/anotherapp/x509/public/#{host_fqdn}.pub"
+        on host, "test -f /etc/pki/simp_apps/anotherapp/x509/cacerts/cacerts.pem"
       end
     end
     context 'with pki = false, and a destination specified' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+shared_examples_for "pki = simp" do
+ it { is_expected.to create_class('pki') }
+ it { is_expected.to compile.with_all_deps }
+ it { is_expected.to create_file('/etc/pki/simp').with_ensure('directory') }
+ it { is_expected.to create_file('/etc/pki/simp/x509').with_ensure('directory')}
+ it { is_expected.to create_file('/etc/pki/simp/x509/private').with_ensure('directory') }
+ it { is_expected.to create_file('/etc/pki/simp/x509/public').with_ensure('directory') }
+ it { is_expected.to create_file('/etc/pki/simp/x509/private/test.example.domain.pem') \
+   .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pem') }
+ it { is_expected.to create_file('/etc/pki/simp/x509/public/test.example.domain.pub') \
+   .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pub') }
+ it { is_expected.to create_file('/etc/pki/simp/x509/cacerts').with_ensure('directory') }
+end
+
 describe 'pki' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
@@ -8,39 +22,24 @@ describe 'pki' do
       end
 
       context 'with default parameters' do
-        it { is_expected.to create_class('pki') }
-        it { is_expected.to compile.with_all_deps }
         it { is_expected.to_not contain_class('auditd') }
-
-        it { is_expected.to create_file('/etc/pki/simp').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/private').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/public').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem') \
-          .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pem') }
-        it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub') \
-          .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pub') }
-        it { is_expected.to create_file('/etc/pki/simp/cacerts').with_ensure('directory') }
+        it_should_behave_like "pki = simp"
       end
 
       context 'with auditd => true' do
         let(:params){{ :auditd => true }}
 
         it { is_expected.to contain_class('auditd') }
-        it { is_expected.to create_file('/etc/pki/simp').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/private').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/public').with_ensure('directory') }
-        it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem') }
-        it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub') }
-        it { is_expected.to create_file('/etc/pki/simp/cacerts').with_ensure('directory') }
+        it_should_behave_like "pki = simp"
       end
 
       [true,false].each do |pki|
         context "with pki => #{pki}" do
           let(:params) {{ :pki => pki }}
 
-          it { is_expected.to create_file('/etc/pki/simp/private/test.example.domain.pem').with_source('puppet:///modules/pki/keydist/test.example.domain/test.example.domain.pem') }
-          it { is_expected.to create_file('/etc/pki/simp/public/test.example.domain.pub').with_source('puppet:///modules/pki/keydist/test.example.domain/test.example.domain.pub') }
-          it { is_expected.to create_file('/etc/pki/simp/cacerts').with_ensure('directory') }
+          it { is_expected.to create_file('/etc/pki/simp/x509/private/test.example.domain.pem').with_source('puppet:///modules/pki/keydist/test.example.domain/test.example.domain.pem') }
+          it { is_expected.to create_file('/etc/pki/simp/x509/public/test.example.domain.pub').with_source('puppet:///modules/pki/keydist/test.example.domain/test.example.domain.pub') }
+          it { is_expected.to create_file('/etc/pki/simp/x509/cacerts').with_ensure('directory') }
         end
       end
 

--- a/spec/defines/copy_spec.rb
+++ b/spec/defines/copy_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 
 shared_examples_for 'pki true' do
+  it { is_expected.to compile.with_all_deps }
   it { is_expected.to create_file('/etc/pki/simp_apps')}
   it { is_expected.to create_file('/etc/pki/simp_apps/foo')}
-  it { is_expected.to create_file('/etc/pki/simp_apps/foo/pki')}
-  it { is_expected.to create_file('/etc/pki/simp_apps/foo/pki/public').with(:source => '/etc/pki/simp/public')}
-  it { is_expected.to create_file('/etc/pki/simp_apps/foo/pki/private').with(:source => '/etc/pki/simp/private')}
-  it { is_expected.to create_file('/etc/pki/simp_apps/foo/pki/cacerts').with(:source => '/etc/pki/simp/cacerts')}
+  it { is_expected.to create_file('/etc/pki/simp_apps/foo/x509')}
+  it { is_expected.to create_file('/etc/pki/simp_apps/foo/x509/public').with(:source => '/etc/pki/simp/x509/public')}
+  it { is_expected.to create_file('/etc/pki/simp_apps/foo/x509/private').with(:source => '/etc/pki/simp/x509/private')}
+  it { is_expected.to create_file('/etc/pki/simp_apps/foo/x509/cacerts').with(:source => '/etc/pki/simp/x509/cacerts')}
+  it { is_expected.to_not create_file('/etc/pki/simp_apps/foo/pki') }
 end
 
 describe 'pki::copy' do
@@ -24,9 +26,9 @@ describe 'pki::copy' do
           it { is_expected.to_not create_file('/etc/pki/simp_apps')}
           it { is_expected.to_not contain_class('pki') }
           it { is_expected.to create_file('/bar/baz/pki')}
-          it { is_expected.to create_file('/bar/baz/pki/public').with(:source => '/etc/pki/simp/public')}
-          it { is_expected.to create_file('/bar/baz/pki/private').with(:source => '/etc/pki/simp/private')}
-          it { is_expected.to create_file('/bar/baz/pki/cacerts').with(:source => '/etc/pki/simp/cacerts')}
+          it { is_expected.to create_file('/bar/baz/pki/public').with(:source => '/etc/pki/simp/x509/public')}
+          it { is_expected.to create_file('/bar/baz/pki/private').with(:source => '/etc/pki/simp/x509/private')}
+          it { is_expected.to create_file('/bar/baz/pki/cacerts').with(:source => '/etc/pki/simp/x509/cacerts')}
         end
 
         context 'with pki => false and specified destination and alternate source' do
@@ -48,15 +50,12 @@ describe 'pki::copy' do
 
         context 'with pki => true and no specified destination' do
           let(:params) {{:pki => true }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_file('/etc/pki/simp_apps')}
           it { is_expected.to_not contain_class('pki') }
           it_should_behave_like "pki true"
         end
 
         context 'with pki => true and specified destination' do
           let(:params) {{:pki => true, :destination => '/bar/baz'}}
-          it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_notify('pki_copy_foo') }
           it { is_expected.to_not contain_class('pki') }
           it_should_behave_like "pki true"
@@ -64,7 +63,6 @@ describe 'pki::copy' do
 
         context 'with pki => simp' do
           let(:params) {{:pki => 'simp'}}
-          it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('pki')}
           it_should_behave_like "pki true"
         end


### PR DESCRIPTION
- SIMP certs are now managed in /etc/pki/simp/x509, and applicaition
  certs in /etc/pki/simp_apps/<app_name>/x509.

SIMP-2472 #comment Done in pki, begin fix in dependent modules