### PR TITLE
(SIMP-4016) Purge /etc/pki/simp_apps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,117 @@
-#
 ---
-puppet-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    key: "$CI_BUILD_REF_NAME"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - gem install bundler
+    - rm -f Gemfile.lock
+    - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
+
+.syntax_checks: &syntax_checks
+  script:
     - bundle exec rake syntax
-puppet-lint: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake lint
-puppet-metadata: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake compare_latest_tag
+
+.spec_tests: &spec_tests
+  script:
     - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags: 
+
+stages:
+  - syntax
+  - unit
+  - acceptance
+  - deploy
+
+puppet-syntax:
+  stage: syntax
+  tags:
     - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags: 
+  image: ruby:2.4
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
+
+# Puppet 4
+unit-ruby-2.1.9:
+  stage: unit
+  tags:
     - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
+  image: ruby:2.1.9
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+# Puppet 5
+unit-ruby-2.4.1:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
-  stage: test
-  tags: 
+puppet4.7-syntax:
+  stage: syntax
+  tags:
     - docker
   image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+  variables:
+    PUPPET_VERSION: '4.7'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
 
-acceptance-test: 
-  stage: test
-  tags: 
+unit-puppet4.7-ruby-2.1:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '4.7'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+puppet5-syntax:
+  stage: syntax
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
+
+unit-puppet5-ruby-2.4:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+acceptance-default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[default]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,32 +13,34 @@
     - rm -f Gemfile.lock
     - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
 
-.syntax_checks: &syntax_checks
+.validation_checks: &validation_checks
   script:
     - bundle exec rake syntax
     - bundle exec rake check:dot_underscore
     - bundle exec rake check:test_file
     - bundle exec rake pkg:check_version
     - bundle exec rake compare_latest_tag
+    - bundle exec rake lint
+    - bundle exec puppet module build
 
 .spec_tests: &spec_tests
   script:
     - bundle exec rake spec
 
 stages:
-  - syntax
+  - validation
   - unit
   - acceptance
   - deploy
 
-puppet-syntax:
-  stage: syntax
+puppet-validation:
+  stage: validation
   tags:
     - docker
   image: ruby:2.4
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *syntax_checks
+  <<: *validation_checks
 
 # Puppet 4
 unit-ruby-2.1.9:
@@ -62,8 +64,8 @@ unit-ruby-2.4.1:
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax:
-  stage: syntax
+puppet4.7-validation:
+  stage: validation
   tags:
     - docker
   image: ruby:2.1
@@ -71,7 +73,7 @@ puppet4.7-syntax:
     PUPPET_VERSION: '4.7'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *syntax_checks
+  <<: *validation_checks
 
 unit-puppet4.7-ruby-2.1:
   stage: unit
@@ -84,8 +86,8 @@ unit-puppet4.7-ruby-2.1:
   <<: *setup_bundler_env
   <<: *spec_tests
 
-puppet5-syntax:
-  stage: syntax
+puppet5-validation:
+  stage: validation
   tags:
     - docker
   image: ruby:2.4
@@ -93,7 +95,7 @@ puppet5-syntax:
     PUPPET_VERSION: '5.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *syntax_checks
+  <<: *validation_checks
 
 unit-puppet5-ruby-2.4:
   stage: unit

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,7 +2,7 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
+--no-empty_string_assignment-check
 --no-trailing_comma-check
 # This is here because the code can't handle lookups in parameters and we have
 # a LOT of those

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,81 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "aPLhijdfdgOoujgCGR66GFBRMCqS/cAeJT66UVZMOdGXd+K2gSEy7Pp/d9u5PzSXCkanOb6aCPiiAVRcKtMTm8MbEn/kqSkJ1h2Lf4/wh/ksbGQ4rPhOeMQSc4EJB01gvc91xPeQlWJe/LjHxCwv8aYoCBQSje1mYGlDFACVwEhEdEDtiKmrnGoKipfzX8u3pk/1qA3YGnpJSCZhNoArykchUpFsTbqRw2dQcpnSg1tVtVFd6uuxcB/+a/MfVcSpoA+vSDL6P1aWJQG0bJkI2XuPI8VDEg+CTRAa0IQ41xw/R4AQP759T0l2wQkHojiaYMJ1IbfsdstfyBR4gKl29caDihINE+2rF6j4EtyIH4bnYH9MRdFVB7akrGR9dQ7MlWaedom8iOltkvbvecutnrK3n2UTVuHyUhzl6VcKMheK8GiL1T+mnTWyHcDZRc6kbuMT3IvULT229Vj1aaTCHvHIGVg/b2rSAda+lsP7KLHarPCnA/H2NsUHV6z8y4jPus3NTDsOVVAU/ognpnxdnglbgUS2ix6ZhTBW0uCWgdxGj4Zinn8c8o5etV2tqMn8rGLb69prrUjUwkl1/3mQIoOfF0dlZ98kE6aUXWIXnSeNDi91NpjCUKKjOZ5YlPVDoZcAwjJG69QyYmbXmpMA7wtAnFpwXDsrkQ2hL6Wn8eg="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  include:
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake compare_latest_tag
+        - bundle exec rake lint
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "BA2ol4vTd4s5DYszfIpkoVF646O9ZbB/Ew/FPdHgSxlXvA6YwFjoD8RohsmbvEXm//VImRLlanjc6OHQSBE4aJ42W/lo/VfHa/hEX99ZJi9E3LrBYuFfc+H4du1GFhYuRAaLr0VtgpZ3B5d43G7c16BOFnyTJB9RNl+5FMW4lOGsHSILTXnxOpABfgbgiOA8Gcv3zXNYhGPRBbSVmSOfV+3thFt9T84DkXLC4gd7AtkpP6EEP0rClgCjeQQ2zK+s/pmviugoCYzA+XgOF8eV2aq8k+9no87eObExqQI2sYhJ9V7G5wpZZxplqSXqcHs7SvCTe/PjzVtIFPa1hYprJy67ikOQEgeBXNmG+9dS+nCMp9yEtDn4s5Kjkhg+j5TKOmipfR542qKDotjYMweVnC/UNlnOClA0Q1rGRyzgk2jez/9sj4L8dcsofvu43c+SkAztdLfg0sxmrtM0aAaNu59F34/hgn/HkvzeXFSDWs23iL+GsJbJk/OyAOF216u1ALL2frf2T5eigTARnWgAduNbV0axhzrnlZIzTB6v185b7pn32iBuFDdo/FPKkyOKmeM7lbAuy9M0jKwDg8vMnGsbQteETmDmOkRWcdfX/6bTSfzGbCYnrH2wN60saK3/hwEFmdRwmf0Ra3ewKGFmVkcjYmYpgEoYgUCQl4+l+LI="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "BA2ol4vTd4s5DYszfIpkoVF646O9ZbB/Ew/FPdHgSxlXvA6YwFjoD8RohsmbvEXm//VImRLlanjc6OHQSBE4aJ42W/lo/VfHa/hEX99ZJi9E3LrBYuFfc+H4du1GFhYuRAaLr0VtgpZ3B5d43G7c16BOFnyTJB9RNl+5FMW4lOGsHSILTXnxOpABfgbgiOA8Gcv3zXNYhGPRBbSVmSOfV+3thFt9T84DkXLC4gd7AtkpP6EEP0rClgCjeQQ2zK+s/pmviugoCYzA+XgOF8eV2aq8k+9no87eObExqQI2sYhJ9V7G5wpZZxplqSXqcHs7SvCTe/PjzVtIFPa1hYprJy67ikOQEgeBXNmG+9dS+nCMp9yEtDn4s5Kjkhg+j5TKOmipfR542qKDotjYMweVnC/UNlnOClA0Q1rGRyzgk2jez/9sj4L8dcsofvu43c+SkAztdLfg0sxmrtM0aAaNu59F34/hgn/HkvzeXFSDWs23iL+GsJbJk/OyAOF216u1ALL2frf2T5eigTARnWgAduNbV0axhzrnlZIzTB6v185b7pn32iBuFDdo/FPKkyOKmeM7lbAuy9M0jKwDg8vMnGsbQteETmDmOkRWcdfX/6bTSfzGbCYnrH2wN60saK3/hwEFmdRwmf0Ra3ewKGFmVkcjYmYpgEoYgUCQl4+l+LI="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "aPLhijdfdgOoujgCGR66GFBRMCqS/cAeJT66UVZMOdGXd+K2gSEy7Pp/d9u5PzSXCkanOb6aCPiiAVRcKtMTm8MbEn/kqSkJ1h2Lf4/wh/ksbGQ4rPhOeMQSc4EJB01gvc91xPeQlWJe/LjHxCwv8aYoCBQSje1mYGlDFACVwEhEdEDtiKmrnGoKipfzX8u3pk/1qA3YGnpJSCZhNoArykchUpFsTbqRw2dQcpnSg1tVtVFd6uuxcB/+a/MfVcSpoA+vSDL6P1aWJQG0bJkI2XuPI8VDEg+CTRAa0IQ41xw/R4AQP759T0l2wQkHojiaYMJ1IbfsdstfyBR4gKl29caDihINE+2rF6j4EtyIH4bnYH9MRdFVB7akrGR9dQ7MlWaedom8iOltkvbvecutnrK3n2UTVuHyUhzl6VcKMheK8GiL1T+mnTWyHcDZRc6kbuMT3IvULT229Vj1aaTCHvHIGVg/b2rSAda+lsP7KLHarPCnA/H2NsUHV6z8y4jPus3NTDsOVVAU/ognpnxdnglbgUS2ix6ZhTBW0uCWgdxGj4Zinn8c8o5etV2tqMn8rGLb69prrUjUwkl1/3mQIoOfF0dlZ98kE6aUXWIXnSeNDi91NpjCUKKjOZ5YlPVDoZcAwjJG69QyYmbXmpMA7wtAnFpwXDsrkQ2hL6Wn8eg="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 
 jobs:
   include:
-    - stage: spec
+    - stage: validate
       rvm: 2.4.1
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Dec 11 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.2-0
+- Ensure that /etc/pki/simp_apps is recursively purged so that old certificates
+  are not left on the system
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
 - Update puppet dependency and remove OBE pe dependency in metadata.json
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,7 +1,0 @@
-Obsoletes: pupmod-pki-test >= 0.0.1
-Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
-Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
-Requires: pupmod-simp-auditd < 8.0.0-0
-Requires: pupmod-simp-auditd >= 7.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0
-Requires: pupmod-simp-simplib < 4.0.0-0

--- a/manifests/copy.pp
+++ b/manifests/copy.pp
@@ -64,6 +64,8 @@ define pki::copy (
   String                         $group       = 'root',
 ) {
 
+  include '::pki::copy::apps_dir'
+
   if !$pki {
     if !$destination {
       fail('You must specify a $destination if $pki false.')
@@ -86,31 +88,20 @@ define pki::copy (
       }
     }
 
-    $_destination = "/etc/pki/simp_apps/${name}/x509"
+    $_destination = "${pki::copy::apps_dir::target}/${name}/x509"
 
-    # Only ensure this directory exists if pki is true or 'simp'.
-    # There is a reasonable expectation if users have pki globally
-    # disabled, they do not intend to use this directory for cert
-    # centralization.
-    ensure_resource('file', '/etc/pki/simp_apps', {
-      'ensure' => 'directory',
-      'owner'  => 'root',
-      'group'  => 'root',
-      'mode'   => '0644'}
-    )
-    file { "/etc/pki/simp_apps/${name}":
+    file { "${pki::copy::apps_dir::target}/${name}":
       ensure  => 'directory',
       owner   => $owner,
       group   => $group,
-      mode    => '0640',
-      require => File['/etc/pki/simp_apps']
+      mode    => '0640'
     }
+
     file { $_destination:
       ensure  => 'directory',
       owner   => $owner,
       group   => $group,
-      mode    => '0640',
-      require => File["/etc/pki/simp_apps/${name}"]
+      mode    => '0640'
     }
 
     if $pki == 'simp' {

--- a/manifests/copy.pp
+++ b/manifests/copy.pp
@@ -91,17 +91,17 @@ define pki::copy (
     $_destination = "${pki::copy::apps_dir::target}/${name}/x509"
 
     file { "${pki::copy::apps_dir::target}/${name}":
-      ensure  => 'directory',
-      owner   => $owner,
-      group   => $group,
-      mode    => '0640'
+      ensure => 'directory',
+      owner  => $owner,
+      group  => $group,
+      mode   => '0640'
     }
 
     file { $_destination:
-      ensure  => 'directory',
-      owner   => $owner,
-      group   => $group,
-      mode    => '0640'
+      ensure => 'directory',
+      owner  => $owner,
+      group  => $group,
+      mode   => '0640'
     }
 
     if $pki == 'simp' {

--- a/manifests/copy/apps_dir.pp
+++ b/manifests/copy/apps_dir.pp
@@ -1,0 +1,29 @@
+# **NOTE: THIS IS A [PRIVATE](https://github.com/puppetlabs/puppetlabs-stdlib#assert_private) CLASS**
+#
+# This class configures the top-level application directory where
+# application-level copies of PKI keys will be housed
+#
+# @param target
+#   The name of the destination directory
+#
+# @param purge
+#   Whether or not to purge unmanaged keys from the directory
+#
+#   * NOTE: It is **highly recommended** that you purge unmanaged keys for
+#     security reasons
+class pki::copy::apps_dir (
+  Stdlib::Absolutepath $target              = '/etc/pki/simp_apps',
+  Boolean              $purge               = true
+){
+  assert_private()
+
+  file { $target:
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    recurse => $purge,
+    purge   => $purge,
+    force   => $purge
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pki",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "SIMP Team",
   "summary": "Manages non-Puppet PKI keys and certificates",
   "license": "Apache-2.0",

--- a/spec/defines/copy_spec.rb
+++ b/spec/defines/copy_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 shared_examples_for 'pki true' do
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to create_file('/etc/pki/simp_apps')}
+  it { is_expected.to create_file('/etc/pki/simp_apps').with_purge(true) }
   it { is_expected.to create_file('/etc/pki/simp_apps/foo')}
   it { is_expected.to create_file('/etc/pki/simp_apps/foo/x509')}
   it { is_expected.to create_file('/etc/pki/simp_apps/foo/x509/public').with(:source => '/etc/pki/simp/x509/public')}
@@ -23,7 +23,7 @@ describe 'pki::copy' do
           let(:params) {{:pki => false, :destination => '/bar/baz' }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to_not create_notify('pki_copy_foo') }
-          it { is_expected.to_not create_file('/etc/pki/simp_apps')}
+          it { is_expected.to create_file('/etc/pki/simp_apps').with_purge(true) }
           it { is_expected.to_not contain_class('pki') }
           it { is_expected.to create_file('/bar/baz/pki')}
           it { is_expected.to create_file('/bar/baz/pki/public').with(:source => '/etc/pki/simp/x509/public')}


### PR DESCRIPTION
This pulls out the creation of the /etc/pki/simp_apps directory and
allows for purging (on by default) as well as renaming the directory.

Old certificates should have never been left on the system for security
reasons.

SIMP-4016 #comment Ensure that simp_apps are purged after stunnel::instance is no longer managed