### PR TITLE
(SIMP-4488) pki: Allow for certnames other than fqdn

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,26 +14,24 @@
 .cache_bundler: &cache_bundler
   cache:
     untracked: true
-    # An attempt at caching between runs (ala Travis CI)
+    # A broad attempt at caching between runs (ala Travis CI)
     key: "${CI_PROJECT_NAMESPACE}__bundler"
     paths:
       - '.vendor'
       - 'vendor'
 
-.setup_env: &setup_env
+.setup_bundler_env: &setup_bundler_env
   before_script:
-    - '(find .vendor | wc -l) || :'
-    - bundle || gem install bundler --no-rdoc --no-ri
-    - rm -f Gemfile.lock
-    - rm -rf pkg/
-    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+    - 'echo Files in cache: $(find .vendor | wc -l) || :'
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
 
-.setup_env_beaker: &setup_env_beaker
-  before_script:
-    - '(find .vendor | wc -l) || :'
-    - rm -f Gemfile.lock
-    - rm -rf pkg/
-    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
 
 .validation_checks: &validation_checks
   script:
@@ -59,7 +57,7 @@ stages:
 # Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup4.7-validation:
+pup4_7-validation:
   stage: validation
   tags:
     - docker
@@ -67,10 +65,10 @@ pup4.7-validation:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.7-unit:
+pup4_7-unit:
   stage: unit
   tags:
     - docker
@@ -78,13 +76,13 @@ pup4.7-unit:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *spec_tests
 
 
 # Puppet 4.8 for SIMP 6.0 + 6.1 support
 # --------------------------------------
-pup4.8-validation:
+pup4_8-validation:
   stage: validation
   tags:
     - docker
@@ -92,10 +90,10 @@ pup4.8-validation:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.8-unit:
+pup4_8-unit:
   stage: unit
   tags:
     - docker
@@ -103,14 +101,14 @@ pup4.8-unit:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *spec_tests
 
 
 # Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup4.10-validation:
+pup4_10-validation:
   stage: validation
   tags:
     - docker
@@ -118,10 +116,10 @@ pup4.10-validation:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.10-unit:
+pup4_10-unit:
   stage: unit
   tags:
     - docker
@@ -129,14 +127,14 @@ pup4.10-unit:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *spec_tests
 
 
 # Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup5.3-validation:
+pup5_3-validation:
   stage: validation
   tags:
     - docker
@@ -144,10 +142,10 @@ pup5.3-validation:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *validation_checks
 
-pup5.3-unit:
+pup5_3-unit:
   stage: unit
   tags:
     - docker
@@ -155,14 +153,14 @@ pup5.3-unit:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *spec_tests
   allow_failure: true
 
 
 # Keep an eye on the latest puppet 5
 # ----------------------------------
-pup5.latest-validation:
+pup5_latest-validation:
   stage: validation
   tags:
     - docker
@@ -170,11 +168,11 @@ pup5.latest-validation:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *validation_checks
   allow_failure: true
 
-pup5.latest-unit:
+pup5_latest-unit:
   stage: unit
   tags:
     - docker
@@ -182,7 +180,7 @@ pup5.latest-unit:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_env
+  <<: *setup_bundler_env
   <<: *spec_tests
   allow_failure: true
 
@@ -190,22 +188,25 @@ pup5.latest-unit:
 
 # Acceptance tests
 # ==============================================================================
-default:
+default-acceptance:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_env_beaker
+  <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10'
   script:
     - bundle exec rake beaker:suites[default]
 
-fips-default:
+fips-acceptance:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_env_beaker
+  <<: *setup_bundler_env
   variables:
+    PUPPET_VERSION: '4.10'
     BEAKER_fips: 'yes'
   script:
     - bundle exec rake beaker:suites[default]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,10 +20,17 @@
       - '.vendor'
       - 'vendor'
 
-.setup_bundler_env: &setup_bundler_env
+.setup_env: &setup_env
   before_script:
     - '(find .vendor | wc -l) || :'
     - bundle || gem install bundler --no-rdoc --no-ri
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.setup_env_beaker: &setup_env_beaker
+  before_script:
+    - '(find .vendor | wc -l) || :'
     - rm -f Gemfile.lock
     - rm -rf pkg/
     - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
@@ -60,7 +67,7 @@ pup4.7-validation:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.7-unit:
@@ -71,7 +78,7 @@ pup4.7-unit:
   variables:
     PUPPET_VERSION: '~> 4.7.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -85,7 +92,7 @@ pup4.8-validation:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.8-unit:
@@ -96,7 +103,7 @@ pup4.8-unit:
   variables:
     PUPPET_VERSION: '~> 4.8.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -111,7 +118,7 @@ pup4.10-validation:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup4.10-unit:
@@ -122,7 +129,7 @@ pup4.10-unit:
   variables:
     PUPPET_VERSION: '~> 4.10.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
 
 
@@ -137,7 +144,7 @@ pup5.3-validation:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
 
 pup5.3-unit:
@@ -148,8 +155,9 @@ pup5.3-unit:
   variables:
     PUPPET_VERSION: '~> 5.3.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
+  allow_failure: true
 
 
 # Keep an eye on the latest puppet 5
@@ -162,7 +170,7 @@ pup5.latest-validation:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *validation_checks
   allow_failure: true
 
@@ -174,7 +182,7 @@ pup5.latest-unit:
   variables:
     PUPPET_VERSION: '~> 5.0'
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env
   <<: *spec_tests
   allow_failure: true
 
@@ -182,21 +190,21 @@ pup5.latest-unit:
 
 # Acceptance tests
 # ==============================================================================
-acceptance-default:
+default:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env_beaker
   script:
     - bundle exec rake beaker:suites[default]
 
-acceptance-default-fips:
+fips-default:
   stage: acceptance
   tags:
     - beaker
   <<: *cache_bundler
-  <<: *setup_bundler_env
+  <<: *setup_env_beaker
   variables:
     BEAKER_fips: 'yes'
   script:

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,8 +2,4 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string_assignment-check
 --no-trailing_comma-check
-# This is here because the code can't handle lookups in parameters and we have
-# a LOT of those
---no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 * Mon Dec 11 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.2-0
 - Ensure that /etc/pki/simp_apps is recursively purged so that old certificates
   are not left on the system
+- Adds a new param, `$certname`, that controls the name of the certs in keydist
+  that will be copied over. This used to be set to `$facts['fqdn']` without an
+  option to change it, now it will default to `$trusted['certname']`
 
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
 - Update puppet dependency and remove OBE pe dependency in metadata.json

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,18 +53,18 @@
 class pki (
   Variant[Boolean,Enum['simp']] $pki                = simplib::lookup('simp_options::pki', { 'default_value' => 'simp' }),
   Stdlib::Absolutepath          $base               = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
-  String                        $private_key_source = "puppet:///modules/${module_name}/keydist/${facts['fqdn']}/${facts['fqdn']}.pem",
-  String                        $public_key_source  = "puppet:///modules/${module_name}/keydist/${facts['fqdn']}/${facts['fqdn']}.pub",
+  String                        $certname           = pick($trusted['certname'], $facts['fqdn']),
+  String                        $private_key_source = "puppet:///modules/${module_name}/keydist/${certname}/${certname}.pem",
+  String                        $public_key_source  = "puppet:///modules/${module_name}/keydist/${certname}/${certname}.pub",
   Boolean                       $auditd             = simplib::lookup('simp_options::auditd', { 'default_value' => false}),
   Boolean                       $sync_purge         = true,
   Array[String]                 $cacerts_sources    = [
     "puppet:///modules/${module_name}/keydist/cacerts",
-    "puppet:///modules/${module_name}/keydist/cacerts/${facts['fqdn']}/cacerts"
+    "puppet:///modules/${module_name}/keydist/cacerts/${certname}/cacerts"
   ]
 ) {
 
   if $pki == 'simp' {
-
     file { '/etc/pki/simp':
       ensure => 'directory',
       owner  => 'root',
@@ -73,11 +73,11 @@ class pki (
       tag    => 'firstrun',
     }
 
-    $_private_key_source = "puppet:///modules/pki_files/keydist/${facts['fqdn']}/${facts['fqdn']}.pem"
-    $_public_key_source  = "puppet:///modules/pki_files/keydist/${facts['fqdn']}/${facts['fqdn']}.pub"
+    $_private_key_source = "puppet:///modules/pki_files/keydist/${certname}/${certname}.pem"
+    $_public_key_source  = "puppet:///modules/pki_files/keydist/${certname}/${certname}.pub"
     $_cacerts_sources    = [
       'puppet:///modules/pki_files/keydist/cacerts',
-      "puppet:///modules/pki_files/keydist/cacerts/${facts['fqdn']}/cacerts"
+      "puppet:///modules/pki_files/keydist/cacerts/${certname}/cacerts"
     ]
   }
   else {
@@ -90,8 +90,8 @@ class pki (
   # for future updates.
   $private_key_dir = "${base}/private"
   $public_key_dir  = "${base}/public"
-  $private_key     = "${private_key_dir}/${facts['fqdn']}.pem"
-  $public_key      = "${public_key_dir}/${facts['fqdn']}.pub"
+  $private_key     = "${private_key_dir}/${certname}.pem"
+  $public_key      = "${public_key_dir}/${certname}.pub"
   $cacerts         = "${base}/cacerts"
   $cacertfile      = "${base}/cacerts/cacerts.pem"
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,25 +1,30 @@
 require 'spec_helper'
 
-shared_examples_for "pki = simp" do
- it { is_expected.to create_class('pki') }
- it { is_expected.to compile.with_all_deps }
- it { is_expected.to create_file('/etc/pki/simp').with_ensure('directory') }
- it { is_expected.to create_file('/etc/pki/simp/x509').with_ensure('directory')}
- it { is_expected.to create_file('/etc/pki/simp/x509/private').with_ensure('directory') }
- it { is_expected.to create_file('/etc/pki/simp/x509/public').with_ensure('directory') }
- it { is_expected.to create_file('/etc/pki/simp/x509/private/test.example.domain.pem') \
-   .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pem') }
- it { is_expected.to create_file('/etc/pki/simp/x509/public/test.example.domain.pub') \
-   .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pub') }
- it { is_expected.to create_file('/etc/pki/simp/x509/cacerts').with_ensure('directory') }
+shared_examples_for "pki = simp", :compile => true  do
+  it { is_expected.to create_class('pki') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_file('/etc/pki/simp').with_ensure('directory') }
+  it { is_expected.to create_file('/etc/pki/simp/x509').with_ensure('directory')}
+  it { is_expected.to create_file('/etc/pki/simp/x509/private').with_ensure('directory') }
+  it { is_expected.to create_file('/etc/pki/simp/x509/public').with_ensure('directory') }
+
+  it { is_expected.to create_file('/etc/pki/simp/x509/private/test.example.domain.pem') \
+    .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pem') }
+
+  it { is_expected.to create_file('/etc/pki/simp/x509/public/test.example.domain.pub') \
+    .with_source('puppet:///modules/pki_files/keydist/test.example.domain/test.example.domain.pub') }
+
+  it { is_expected.to create_file('/etc/pki/simp/x509/cacerts').with_ensure('directory') }
 end
 
 describe 'pki' do
+
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       let(:facts) do
         facts.merge( { :fqdn => 'test.example.domain' } )
       end
+      let(:node) { 'test.example.domain' }
 
       context 'with default parameters' do
         it { is_expected.to_not contain_class('auditd') }


### PR DESCRIPTION
- Adds a new param, `$certname`, that controls the name of the certs in
  keydist that will be copied over. This used to be set to
  `$facts['fqdn']` without an option to change it, now it will default
  to `$trusted['certname']`

SIMP-4488 #close